### PR TITLE
减少插件体积

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,6 @@ repositories {
 
 dependencies {
     implementation platform('run.halo.tools.platform:plugin:2.6.0-SNAPSHOT')
-    implementation 'cn.hutool:hutool-json:5.8.20'
-    implementation 'cn.hutool:hutool-http:5.8.20'
     compileOnly 'run.halo.app:api'
     testImplementation 'run.halo.app:api'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.3.0
+version=1.3.1

--- a/src/main/java/com/stonewu/sitepush/setting/BaiduSettingProvider.java
+++ b/src/main/java/com/stonewu/sitepush/setting/BaiduSettingProvider.java
@@ -1,8 +1,8 @@
 package com.stonewu.sitepush.setting;
 
-import java.net.Proxy;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import reactor.netty.transport.ProxyProvider;
 
 /**
  * @author Erzbir
@@ -64,8 +64,11 @@ public class BaiduSettingProvider implements PushSettingProvider {
     }
 
     @Override
-    public Proxy.Type getProxyType() {
-        return Proxy.Type.valueOf(setting.getBaiduProxyType());
+    public ProxyProvider.Proxy getProxyType() {
+        if (setting.getBaiduProxyType().equals("SOCKS")) {
+            return ProxyProvider.Proxy.SOCKS5;
+        }
+        return ProxyProvider.Proxy.valueOf(setting.getBaiduProxyType());
     }
 
     @Override

--- a/src/main/java/com/stonewu/sitepush/setting/BingPushSettingProvider.java
+++ b/src/main/java/com/stonewu/sitepush/setting/BingPushSettingProvider.java
@@ -3,6 +3,7 @@ package com.stonewu.sitepush.setting;
 import java.net.Proxy;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import reactor.netty.transport.ProxyProvider;
 
 /**
  * @author Erzbir
@@ -65,8 +66,11 @@ public class BingPushSettingProvider implements PushSettingProvider {
     }
 
     @Override
-    public Proxy.Type getProxyType() {
-        return Proxy.Type.valueOf(setting.getBingProxyType());
+    public ProxyProvider.Proxy getProxyType() {
+        if (setting.getBingProxyType().equals("SOCKS")) {
+            return ProxyProvider.Proxy.SOCKS5;
+        }
+        return ProxyProvider.Proxy.valueOf(setting.getBingProxyType());
     }
 
     @Override

--- a/src/main/java/com/stonewu/sitepush/setting/BingPushSettingProvider.java
+++ b/src/main/java/com/stonewu/sitepush/setting/BingPushSettingProvider.java
@@ -1,6 +1,5 @@
 package com.stonewu.sitepush.setting;
 
-import java.net.Proxy;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import reactor.netty.transport.ProxyProvider;

--- a/src/main/java/com/stonewu/sitepush/setting/GooglePushSettingProvider.java
+++ b/src/main/java/com/stonewu/sitepush/setting/GooglePushSettingProvider.java
@@ -1,8 +1,8 @@
 package com.stonewu.sitepush.setting;
 
-import java.net.Proxy;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import reactor.netty.transport.ProxyProvider;
 
 /**
  * @author Erzbir
@@ -65,8 +65,11 @@ public class GooglePushSettingProvider implements PushSettingProvider {
     }
 
     @Override
-    public Proxy.Type getProxyType() {
-        return Proxy.Type.valueOf(setting.getGoogleProxyType());
+    public ProxyProvider.Proxy getProxyType() {
+        if (setting.getGoogleProxyType().equals("SOCKS")) {
+            return ProxyProvider.Proxy.SOCKS5;
+        }
+        return ProxyProvider.Proxy.valueOf(setting.getGoogleProxyType());
     }
 
     @Override

--- a/src/main/java/com/stonewu/sitepush/setting/PushSettingProvider.java
+++ b/src/main/java/com/stonewu/sitepush/setting/PushSettingProvider.java
@@ -1,5 +1,6 @@
 package com.stonewu.sitepush.setting;
 
+import reactor.netty.transport.ProxyProvider;
 import java.net.Proxy;
 
 /**
@@ -40,7 +41,7 @@ public interface PushSettingProvider {
 
     Boolean isUseProxy();
 
-    Proxy.Type getProxyType();
+    ProxyProvider.Proxy getProxyType();
 
     String getProxyAddress();
 

--- a/src/main/java/com/stonewu/sitepush/setting/PushSettingProvider.java
+++ b/src/main/java/com/stonewu/sitepush/setting/PushSettingProvider.java
@@ -1,7 +1,6 @@
 package com.stonewu.sitepush.setting;
 
 import reactor.netty.transport.ProxyProvider;
-import java.net.Proxy;
 
 /**
  * @author Erzbir

--- a/src/main/java/com/stonewu/sitepush/strategy/BaiduPushStrategy.java
+++ b/src/main/java/com/stonewu/sitepush/strategy/BaiduPushStrategy.java
@@ -1,13 +1,17 @@
 package com.stonewu.sitepush.strategy;
 
-import cn.hutool.http.HttpRequest;
-import cn.hutool.http.HttpResponse;
 import com.stonewu.sitepush.DefaultSettingFetcher;
 import com.stonewu.sitepush.setting.BaiduPushSetting;
 import com.stonewu.sitepush.setting.BaiduSettingProvider;
 import com.stonewu.sitepush.setting.PushSettingProvider;
+import com.stonewu.sitepush.utils.HttpResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 @Component
 @Slf4j
@@ -34,11 +38,13 @@ public class BaiduPushStrategy extends AbstractPushStrategy implements PushStrat
     }
 
     @Override
-    protected HttpResponse request(String siteUrl, String pageLink,
-        PushSettingProvider settingProvider) {
+    protected Mono<HttpResponse> request(String siteUrl, String pageLink,
+        PushSettingProvider settingProvider)
+        throws IOException, ExecutionException, InterruptedException {
         String baiduPushUrl = String.format(PUSH_ENDPOINT, siteUrl, settingProvider.getAccess());
         log.info("Pushing to baidu webmasters: {}", baiduPushUrl);
-        HttpRequest request = HttpRequest.post(baiduPushUrl).body(siteUrl + pageLink);
-        return httpRequestSender.request(request);
+        return httpRequestSender.request(baiduPushUrl, HttpMethod.POST,
+            new DefaultHttpHeaders(),
+            siteUrl + pageLink);
     }
 }

--- a/src/main/java/com/stonewu/sitepush/strategy/GooglePushStrategy.java
+++ b/src/main/java/com/stonewu/sitepush/strategy/GooglePushStrategy.java
@@ -1,23 +1,28 @@
 package com.stonewu.sitepush.strategy;
 
 
-import cn.hutool.core.lang.Dict;
-import cn.hutool.http.HttpRequest;
-import cn.hutool.http.HttpResponse;
-import cn.hutool.json.JSONUtil;
 import com.stonewu.sitepush.DefaultSettingFetcher;
 import com.stonewu.sitepush.setting.GooglePushSetting;
 import com.stonewu.sitepush.setting.GooglePushSettingProvider;
 import com.stonewu.sitepush.setting.PushSettingProvider;
+import com.stonewu.sitepush.utils.HttpResponse;
 import com.stonewu.sitepush.utils.JWTSignUtil;
 import com.stonewu.sitepush.utils.PemReader;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import run.halo.app.infra.utils.JsonUtils;
 
 /**
  * @author Erzbir
@@ -27,14 +32,13 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class GooglePushStrategy extends AbstractPushStrategy implements PushStrategy {
 
+    public static final String PUSH_ENDPOINT =
+        "https://indexing.googleapis.com/v3/urlNotifications:publish";
+    public static final String UPDATE_TYPE = "URL_UPDATED";
+
     public GooglePushStrategy(DefaultSettingFetcher settingFetcher) {
         super(settingFetcher);
     }
-
-    public static final String PUSH_ENDPOINT =
-        "https://indexing.googleapis.com/v3/urlNotifications:publish";
-
-    public static final String UPDATE_TYPE = "URL_UPDATED";
 
     @Override
     public String getPushType() {
@@ -51,25 +55,24 @@ public class GooglePushStrategy extends AbstractPushStrategy implements PushStra
     }
 
     @Override
-    protected HttpResponse request(String siteUrl, String pageLink,
+    protected Mono<HttpResponse> request(String siteUrl, String pageLink,
         PushSettingProvider settingProvider) throws Exception {
         log.info("Pushing to google webmasters: {}", PUSH_ENDPOINT);
         String token = GooglePushTokenCreator.createToken(
-            JSONUtil.toBean(settingProvider.getAccess(),
+            JsonUtils.jsonToObject(settingProvider.getAccess(),
                 GooglePushTokenCreator.ServiceAccountCredentials.class),
             URI.create(PUSH_ENDPOINT));
         return publish(siteUrl + pageLink, token);
     }
 
-    public HttpResponse publish(String url, String token) {
+    public Mono<HttpResponse> publish(String url, String token) {
         GooglePushBody body = new GooglePushBody();
         body.setType(UPDATE_TYPE);
         body.setUrl(url);
-        HttpRequest request = HttpRequest
-            .post(PUSH_ENDPOINT)
-            .bearerAuth(token)
-            .body(JSONUtil.toJsonStr(body));
-        return httpRequestSender.request(request);
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.AUTHORIZATION, "Bearer " + token);
+        return httpRequestSender.request(PUSH_ENDPOINT, HttpMethod.POST, headers,
+            JsonUtils.objectToJson(body));
     }
 
     private static class GooglePushTokenCreator {
@@ -79,19 +82,19 @@ public class GooglePushStrategy extends AbstractPushStrategy implements PushStra
             GeneralSecurityException {
             String privateKeyId = credentials.private_key_id;
             String privateKey = credentials.private_key;
-            Dict header = Dict.create();
-            header.set("alg", "RS256")
-                .set("kid", privateKeyId)
-                .set("typ", "JWT");
+            Map<String, Object> header = new HashMap<>();
+            header.put("alg", "RS256");
+            header.put("kid", privateKeyId);
+            header.put("typ", "JWT");
 
-            Dict payload = Dict.create();
+            Map<String, Object> payload = new HashMap<>();
             String clientEmail = credentials.client_email;
             long l = System.currentTimeMillis();
-            payload.set("iss", clientEmail)
-                .set("aud", getUriForSelfSignedJWT(endpoint))
-                .set("sub", clientEmail)
-                .set("iat", l / 1000)
-                .set("exp", l / 1000 + 3600);
+            payload.put("iss", clientEmail);
+            payload.put("aud", getUriForSelfSignedJWT(endpoint));
+            payload.put("sub", clientEmail);
+            payload.put("iat", l / 1000);
+            payload.put("exp", l / 1000 + 3600);
             return JWTSignUtil.getInstance()
                 .signUsingRsaSha256(PemReader.getInstance().getPrivateKeyFromPEM(privateKey, "RSA"),
                     header,

--- a/src/main/java/com/stonewu/sitepush/utils/AbstractHttpRequestSender.java
+++ b/src/main/java/com/stonewu/sitepush/utils/AbstractHttpRequestSender.java
@@ -35,8 +35,9 @@ public abstract class AbstractHttpRequestSender implements HttpRequestSender {
     @Override
     public Mono<HttpResponse> request(String requestUrl, HttpMethod httpMethod,
         HttpHeaders httpHeaders, String body) {
-        httpClient = httpClient.protocol(HttpProtocol.HTTP11).baseUrl(requestUrl);
+        httpClient = httpClient.protocol(HttpProtocol.HTTP11);
         return getRequestSender(httpMethod, httpHeaders)
+            .uri(requestUrl)
             .send(ByteBufFlux.fromString(Mono.just(body)))
             .responseSingle((response, byteBufMono) -> Mono.just(
                 new HttpResponse(response.status().code(), byteBufMono.asString())));

--- a/src/main/java/com/stonewu/sitepush/utils/AbstractHttpRequestSender.java
+++ b/src/main/java/com/stonewu/sitepush/utils/AbstractHttpRequestSender.java
@@ -1,0 +1,47 @@
+package com.stonewu.sitepush.utils;
+
+
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import lombok.Getter;
+import lombok.Setter;
+import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufFlux;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+/**
+ * @author Erzbir
+ * @Date 2023/10/29
+ */
+@Getter
+@Setter
+public abstract class AbstractHttpRequestSender implements HttpRequestSender {
+    protected int timeOut;
+    protected HttpClient httpClient;
+
+    protected AbstractHttpRequestSender(int timeOut) {
+        this.timeOut = timeOut;
+        httpClient = HttpClient.create();
+        httpClient.responseTimeout(Duration.ofMillis(timeOut));
+    }
+
+    protected AbstractHttpRequestSender() {
+        this(5000);
+    }
+
+    @Override
+    public Mono<HttpResponse> request(String requestUrl, HttpMethod httpMethod,
+        HttpHeaders httpHeaders, String body) {
+        httpClient = httpClient.protocol(HttpProtocol.HTTP11).baseUrl(requestUrl);
+        return getRequestSender(httpMethod, httpHeaders)
+            .send(ByteBufFlux.fromString(Mono.just(body)))
+            .responseSingle((response, byteBufMono) -> Mono.just(
+                new HttpResponse(response.status().code(), byteBufMono.asString())));
+    }
+
+    protected abstract HttpClient.RequestSender getRequestSender(HttpMethod httpMethod,
+        HttpHeaders httpHeaders);
+}

--- a/src/main/java/com/stonewu/sitepush/utils/DefaultHttpRequestSender.java
+++ b/src/main/java/com/stonewu/sitepush/utils/DefaultHttpRequestSender.java
@@ -1,31 +1,33 @@
 package com.stonewu.sitepush.utils;
 
-import cn.hutool.http.HttpRequest;
-import cn.hutool.http.HttpResponse;
-import lombok.AllArgsConstructor;
+
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import reactor.netty.http.client.HttpClient;
 
 /**
  * @author Erzbir
  * @Date 2023/10/23
  */
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Setter
-public class DefaultHttpRequestSender implements HttpRequestSender {
-    private int timeOut = 5000;
-
-    @Override
-    public HttpResponse request(HttpRequest request) {
-        return request.timeout(timeOut).setConnectionTimeout(timeOut).setReadTimeout(timeOut)
-            .execute();
-    }
+@Slf4j
+public class DefaultHttpRequestSender extends AbstractHttpRequestSender
+    implements HttpRequestSender {
 
     @Override
     public boolean isProxy() {
         return false;
+    }
+
+    @Override
+    public HttpClient.RequestSender getRequestSender(HttpMethod httpMethod,
+        HttpHeaders httpHeaders) {
+        return httpClient
+            .headers(builder -> builder.add(httpHeaders))
+            .request(httpMethod);
     }
 }

--- a/src/main/java/com/stonewu/sitepush/utils/HttpRequestSender.java
+++ b/src/main/java/com/stonewu/sitepush/utils/HttpRequestSender.java
@@ -1,14 +1,16 @@
 package com.stonewu.sitepush.utils;
 
-import cn.hutool.http.HttpRequest;
-import cn.hutool.http.HttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import reactor.core.publisher.Mono;
 
 /**
  * @author Erzbir
  * @Date 2023/10/23
  */
 public interface HttpRequestSender {
-    HttpResponse request(HttpRequest request);
+    Mono<HttpResponse> request(String requestUrl, HttpMethod httpMethod, HttpHeaders httpHeaders,
+        String body);
 
     boolean isProxy();
 }

--- a/src/main/java/com/stonewu/sitepush/utils/HttpResponse.java
+++ b/src/main/java/com/stonewu/sitepush/utils/HttpResponse.java
@@ -1,0 +1,10 @@
+package com.stonewu.sitepush.utils;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Erzbir
+ * @Date 2023/10/30
+ */
+public record HttpResponse(int code, Mono<String> body) {
+}

--- a/src/main/java/com/stonewu/sitepush/utils/JWTSignUtil.java
+++ b/src/main/java/com/stonewu/sitepush/utils/JWTSignUtil.java
@@ -1,12 +1,12 @@
 package com.stonewu.sitepush.utils;
 
-import cn.hutool.core.codec.Base64;
-import cn.hutool.core.lang.Dict;
-import cn.hutool.json.JSONUtil;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.Signature;
+import java.util.Base64;
+import java.util.Map;
+import run.halo.app.infra.utils.JsonUtils;
 
 /**
  * @author Erzbir
@@ -23,18 +23,20 @@ public class JWTSignUtil {
 
     public String signUsingRsaSha256(
         PrivateKey privateKey,
-        Dict header,
-        Dict payload)
+        Map<String, ?> header,
+        Map<String, ?> payload)
         throws GeneralSecurityException {
         String headerBase64 =
-            Base64.encodeUrlSafe(JSONUtil.toJsonStr(header).getBytes(StandardCharsets.UTF_8));
+            Base64.getUrlEncoder()
+                .encodeToString(JsonUtils.objectToJson(header).getBytes(StandardCharsets.UTF_8));
         String payloadBase64 =
-            Base64.encodeUrlSafe(JSONUtil.toJsonStr(payload).getBytes(StandardCharsets.UTF_8));
+            Base64.getUrlEncoder()
+                .encodeToString(JsonUtils.objectToJson(payload).getBytes(StandardCharsets.UTF_8));
         String content = headerBase64 + "." + payloadBase64;
         byte[] contentBytes = content.getBytes();
         byte[] signature = SecurityUtil.getInstance()
             .sign(Signature.getInstance("SHA256withRSA"), contentBytes, privateKey);
-        return content + "." + Base64.encodeUrlSafe(signature);
+        return content + "." + Base64.getUrlEncoder().encodeToString(signature);
     }
 
 

--- a/src/main/java/com/stonewu/sitepush/utils/PemReader.java
+++ b/src/main/java/com/stonewu/sitepush/utils/PemReader.java
@@ -1,6 +1,5 @@
 package com.stonewu.sitepush.utils;
 
-import cn.hutool.core.codec.Base64;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
@@ -9,6 +8,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
 
 /**
  * @author Erzbir
@@ -40,7 +40,7 @@ public class PemReader {
                 }
             }
 
-            byte[] keyBytes = Base64.decode(keyContent.toString());
+            byte[] keyBytes = Base64.getDecoder().decode(keyContent.toString());
             PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
             return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
         } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {

--- a/src/main/java/com/stonewu/sitepush/utils/Proxy.java
+++ b/src/main/java/com/stonewu/sitepush/utils/Proxy.java
@@ -1,0 +1,13 @@
+package com.stonewu.sitepush.utils;
+
+import java.net.SocketAddress;
+import reactor.netty.transport.ProxyProvider;
+
+/**
+ * @author Erzbir
+ * @Date 2023/10/29
+ */
+
+public record Proxy(ProxyProvider.Proxy type, SocketAddress address) {
+
+}

--- a/src/main/java/com/stonewu/sitepush/utils/ProxyHttpRequestSender.java
+++ b/src/main/java/com/stonewu/sitepush/utils/ProxyHttpRequestSender.java
@@ -1,10 +1,12 @@
 package com.stonewu.sitepush.utils;
 
-import cn.hutool.http.HttpRequest;
-import cn.hutool.http.HttpResponse;
-import java.net.Proxy;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import java.net.InetSocketAddress;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import reactor.netty.http.client.HttpClient;
 
 /**
  * @author Erzbir
@@ -12,18 +14,22 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-public class ProxyHttpRequestSender implements HttpRequestSender {
+@Slf4j
+public class ProxyHttpRequestSender extends AbstractHttpRequestSender implements HttpRequestSender {
     private Proxy proxy;
-    private DefaultHttpRequestSender defaultHttpRequestSender;
 
     public ProxyHttpRequestSender(Proxy proxy) {
         this.proxy = proxy;
-        defaultHttpRequestSender = new DefaultHttpRequestSender();
     }
 
     @Override
-    public HttpResponse request(HttpRequest request) {
-        return defaultHttpRequestSender.request(request.setProxy(proxy));
+    public HttpClient.RequestSender getRequestSender(HttpMethod httpMethod,
+        HttpHeaders httpHeaders) {
+        return httpClient
+            .headers(builder -> builder.add(httpHeaders))
+            .proxy(proxyOptions -> proxyOptions.type(proxy.type())
+                .address((InetSocketAddress) proxy.address()))
+            .request(httpMethod);
     }
 
     @Override


### PR DESCRIPTION
用 halo 内置的 `reactor-netty` 和 json 工具 代替了 `hutool-http` 和 `hutool-json`