### PR TITLE
fix: 修复谷歌 batch post 的报文拼接错误

### DIFF
--- a/src/main/java/com/stonewu/sitepush/strategy/GooglePushStrategy.java
+++ b/src/main/java/com/stonewu/sitepush/strategy/GooglePushStrategy.java
@@ -99,9 +99,9 @@ public class GooglePushStrategy extends AbstractPushStrategy implements PushStra
                 .append("Content-ID: ").append(contentId++).append("\n")
                 .append("\n")
                 .append("POST").append(" ").append(API_URL).append("\n")
-                .append("Content-Type: application/json\r\n")
-                .append("accept: application/json\n")
-                .append("content-length: ").append(requestStr.length()).append("\n")
+                .append("Content-Type: application/json").append("\n")
+                .append("accept: application/json").append("\n")
+                .append("\n")
                 .append(requestStr).append("\n");
         }
         batchBody.append("--").append(boundary).append("--");


### PR DESCRIPTION
fix: #51 