### PR TITLE
fix: some NPE and when pushStatus eq -1 still need push

### DIFF
--- a/src/main/java/com/stonewu/sitepush/reconciler/PostPushReconciler.java
+++ b/src/main/java/com/stonewu/sitepush/reconciler/PostPushReconciler.java
@@ -32,7 +32,7 @@ public class PostPushReconciler extends AbstractPushReconciler
     public Result reconcile(Request request) {
         PublishExtension publishExtension = client.fetch(Post.class, request.name())
             .blockOptional()
-            .map(PostAdapter::new).get();
+            .map(PostAdapter::new).orElseThrow();
         return reconcile(publishExtension);
     }
 

--- a/src/main/java/com/stonewu/sitepush/reconciler/PostPushReconciler.java
+++ b/src/main/java/com/stonewu/sitepush/reconciler/PostPushReconciler.java
@@ -57,7 +57,7 @@ public class PostPushReconciler extends AbstractPushReconciler
 
         @Override
         public String getPermalink() {
-            return post.getStatus().getPermalink();
+            return post.getStatusOrDefault().getPermalink();
         }
 
         @Override
@@ -71,8 +71,8 @@ public class PostPushReconciler extends AbstractPushReconciler
         }
         @Override
         public boolean isObserved() {
-            if(post.getMetadata() != null && post.getStatus() != null){
-                return post.getMetadata().getVersion().equals(post.getStatus().getObservedVersion());
+            if(post.getMetadata() != null && post.getStatusOrDefault() != null){
+                return post.getMetadata().getVersion().equals(post.getStatusOrDefault().getObservedVersion());
             }
             return false;
         }

--- a/src/main/java/com/stonewu/sitepush/reconciler/SinglePagePushReconciler.java
+++ b/src/main/java/com/stonewu/sitepush/reconciler/SinglePagePushReconciler.java
@@ -58,7 +58,7 @@ public class SinglePagePushReconciler extends AbstractPushReconciler
 
         @Override
         public String getPermalink() {
-            return singlePage.getStatus().getPermalink();
+            return singlePage.getStatusOrDefault().getPermalink();
         }
 
         @Override
@@ -73,7 +73,7 @@ public class SinglePagePushReconciler extends AbstractPushReconciler
 
         @Override
         public boolean isObserved() {
-            return singlePage.getMetadata().getVersion().equals(singlePage.getStatus().getObservedVersion());
+            return singlePage.getMetadata().getVersion().equals(singlePage.getStatusOrDefault().getObservedVersion());
         }
     }
 }

--- a/src/main/java/com/stonewu/sitepush/reconciler/SinglePagePushReconciler.java
+++ b/src/main/java/com/stonewu/sitepush/reconciler/SinglePagePushReconciler.java
@@ -40,7 +40,7 @@ public class SinglePagePushReconciler extends AbstractPushReconciler
     public Result reconcile(Request request) {
         PublishExtension publishExtension = client.fetch(SinglePage.class, request.name())
             .blockOptional()
-            .map(SinglePageAdapter::new).get();
+            .map(SinglePageAdapter::new).orElseThrow();
         return reconcile(publishExtension);
     }
 

--- a/src/main/java/com/stonewu/sitepush/service/PushServiceImpl.java
+++ b/src/main/java/com/stonewu/sitepush/service/PushServiceImpl.java
@@ -68,7 +68,8 @@ public class PushServiceImpl implements PushService {
     }
 
     public boolean isNeedPush(String cacheKey) {
-        return GlobalCache.PUSH_CACHE.get(cacheKey) == null
-            || GlobalCache.PUSH_CACHE.get(cacheKey).getPushStatus() != 1;
+        var pushUnique = GlobalCache.PUSH_CACHE.get(cacheKey);
+        return pushUnique == null
+            || pushUnique.getPushStatus() == 0;
     }
 }


### PR DESCRIPTION
see log, NPE:
```text
2024-05-27T21:10:43.000+08:00 ERROR 7 --- [com.stonewu.sitepush.reconciler.PostPushReconciler-t-1] r.h.a.e.controller.DefaultController     : Reconciler in com.stonewu.sitepush.reconciler.PostPushReconciler-worker-1 aborted with an error, re-enqueuing...

java.lang.NullPointerException: Cannot invoke "run.halo.app.core.extension.content.Post$PostStatus.getPermalink()" because the return value of "run.halo.app.core.extension.content.Post.getStatus()" is null
	at com.stonewu.sitepush.reconciler.PostPushReconciler$PostAdapter.getPermalink(PostPushReconciler.java:60) ~[na:na]
	at com.stonewu.sitepush.reconciler.AbstractPushReconciler.reconcile(AbstractPushReconciler.java:55) ~[na:na]
	at com.stonewu.sitepush.reconciler.PostPushReconciler.reconcile(PostPushReconciler.java:36) ~[na:na]
	at com.stonewu.sitepush.reconciler.PostPushReconciler.reconcile(PostPushReconciler.java:21) ~[na:na]
	at run.halo.app.extension.controller.DefaultController$Worker.run(DefaultController.java:163) ~[api-2.16.0-SNAPSHOT.jar:na]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[na:na]
	at java.base/java.lang.Thread.run(Unknown Source) ~[na:na]
```

see log, when status eq 1, still repush, causing subsequent push to be skipped
```text
2024-05-28T16:25:03.335+08:00  INFO 7 --- [hReconciler-t-1] c.s.sitepush.service.PushServiceImpl     : PushUnique(lastPushTime=2024-05-28T07:30:00.654152164Z, pushType=baidu, pushUniqueKey=Post:169, pushStatus=-1)
2024-05-28T16:25:03.335+08:00  INFO 7 --- [hReconciler-t-1] c.s.sitepush.service.PushServiceImpl     : true (pushUnique.getPushStatus() != 1)
```

评价，立刻发版 :P